### PR TITLE
support debug info strip from precompiled script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,3 +35,4 @@
 * Converted API documentaion into markdown format.
 * Reverted f5de9d4. It was affecting precompiled scripts size in a negative way.    
   However, it's probably still a packer issue, so this might get back at some point.
+* Added `-d` flag to mujs executable, which can be used to strip debug information from precompiled script, to produce smaller binary.

--- a/include/mujs/mujs.h
+++ b/include/mujs/mujs.h
@@ -265,7 +265,10 @@ void js_pushconstu(js_State *J, const char *v, int isunicode);
 /* fetch instance type name from the constructor */
 const char* js_resolvetypename(js_State *J, int idx);
 /* precompile binary */
-int js_dumpscript(js_State *J, int idx, char **buf);
+enum {
+	JS_BINSTRIPDEBUG = 1
+};
+int js_dumpscript(js_State *J, int idx, char **buf, int flags);
 void js_loadbin(js_State *J, const char *source, int length);
 int js_ploadbin(js_State *J, const char *source, int length);
 void js_loadbinfile(js_State *J, const char *filename);

--- a/src/jsdump.c
+++ b/src/jsdump.c
@@ -942,7 +942,7 @@ static void jsC_dumpfuncbin_string(js_State *J, js_Buffer *buf, hashtable_t *str
 		jsbuf_putu16(J, buf, 0);
 }
 
-static void jsC_dumpfuncbin(js_State *J, js_Function *F, js_Buffer *sb, hashtable_t *strings)
+static void jsC_dumpfuncbin(js_State *J, js_Function *F, js_Buffer *sb, hashtable_t *strings, int flags)
 {
 	int i;
 	int meta = 0;
@@ -950,16 +950,20 @@ static void jsC_dumpfuncbin(js_State *J, js_Function *F, js_Buffer *sb, hashtabl
 	jsbuf_puti8(J, sb, BF_FUNCDECL);	
 	/* write meta */
 	jsbuf_puti8(J, sb, BF_FUNCMETA);
-	jsC_dumpfuncbin_string(J, sb, strings, F->name);
+	if (!(flags & JS_BINSTRIPDEBUG))
+		jsC_dumpfuncbin_string(J, sb, strings, F->name);
 	BITSET(meta, 0, F->script);
 	BITSET(meta, 1, F->lightweight);
 	BITSET(meta, 2, F->strict);
 	BITSET(meta, 3, F->arguments);
 	jsbuf_puti8(J, sb, meta);
 	jsbuf_putu16(J, sb, F->numparams);
-	jsC_dumpfuncbin_string(J, sb, strings, F->filename);
-	jsbuf_puti32(J, sb, F->line);
-	jsbuf_puti32(J, sb, F->lastline);
+	if (!(flags & JS_BINSTRIPDEBUG))
+	{
+		jsC_dumpfuncbin_string(J, sb, strings, F->filename);
+		jsbuf_puti32(J, sb, F->line);
+		jsbuf_puti32(J, sb, F->lastline);
+	}
 	/* write tables */
 	if (F->numlen) {
 		jsbuf_puti8(J, sb, BF_FUNCNUMS);
@@ -995,19 +999,21 @@ static void jsC_dumpfuncbin(js_State *J, js_Function *F, js_Buffer *sb, hashtabl
 		jsbuf_puti8(J, sb, BF_FUNCFUNS);
 		jsbuf_puti32(J, sb, F->funlen);
 		for (i = 0; i < F->funlen; i++)
-			jsC_dumpfuncbin(J, F->funtab[i], sb, strings);
+			jsC_dumpfuncbin(J, F->funtab[i], sb, strings, flags);
 	}
 }
 
-js_Buffer js_dumpfuncbin(js_State *J, js_Function *F)
+js_Buffer js_dumpfuncbin(js_State *J, js_Function *F, int flags)
 {
+	int headerFlags = 0;
 	js_Buffer buf;
 	jsbuf_init(J, &buf, 512);
 	hashtable_t strings;
 	hashtable_init(&strings, sizeof(uint32_t), 256, NULL);	
 	jsbuf_puti32(J, &buf, 0x736a756d);
-	jsbuf_puti32(J, &buf, 0);
-	jsC_dumpfuncbin(J, F, &buf, &strings);
+	BITSET(headerFlags, 0, flags & JS_BINSTRIPDEBUG);
+	jsbuf_puti32(J, &buf, headerFlags);
+	jsC_dumpfuncbin(J, F, &buf, &strings, flags);
 	hashtable_term(&strings);
 	return buf;
 }

--- a/src/jserror.c
+++ b/src/jserror.c
@@ -17,11 +17,11 @@ static int jsB_stacktrace(js_State *J, int skip)
 		int line = J->trace[n].line;
 		if (line > 0) {
 			if (name[0])
-				snprintf(buf, sizeof buf, "\n\tat %s (%s:%d)", name, file, line);
+				snprintf(buf, sizeof buf, "\n\tat %s (%s:%d)", name, S_EITHER_STR(file, "??"), line);
 			else
-				snprintf(buf, sizeof buf, "\n\tat %s:%d", file, line);
+				snprintf(buf, sizeof buf, "\n\tat %s:%d", S_EITHER_STR(file, "??"), line);
 		} else
-			snprintf(buf, sizeof buf, "\n\tat %s (%s)", name, file);
+			snprintf(buf, sizeof buf, "\n\tat %s (%s)", S_EITHER_STR(name, "??"), S_EITHER_STR(file, "??"));
 		js_pushstring(J, buf);
 		if (n < J->tracetop - skip)
 			js_concat(J);

--- a/src/jsvalue.c
+++ b/src/jsvalue.c
@@ -787,12 +787,12 @@ const char* js_resolvetypename(js_State *J, int idx)
     return jsV_resolvetypename(J, js_tovalue(J, idx), "");
 }
 
-int js_dumpscript(js_State *J, int idx, char **buffer)
+int js_dumpscript(js_State *J, int idx, char **buffer, int flags)
 {
 	js_Object *obj = js_toobject(J, idx);
 	if (obj->type != JS_CSCRIPT)
 		js_typeerror(J, "expected script value");
-	js_Buffer buf = js_dumpfuncbin(J, obj->u.f.function);
+	js_Buffer buf = js_dumpfuncbin(J, obj->u.f.function, flags);
 	if (buf.data == NULL)
 		return 0;
 	if (buf.n == 0) {

--- a/src/jsvalue.h
+++ b/src/jsvalue.h
@@ -199,7 +199,7 @@ typedef enum {
 	BF_FUNCFUNS 
 } binfuncseg_t;
 
-js_Buffer js_dumpfuncbin(js_State *J, js_Function *F);
+js_Buffer js_dumpfuncbin(js_State *J, js_Function *F, int flags);
 js_Function *jsV_newfunction(js_State *J);
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -308,6 +308,7 @@ static void usage(void)
 	fprintf(stderr, "\t-e: Evaluate string.\n");
 	fprintf(stderr, "\t-c: Precompile script.\n");
 	fprintf(stderr, "\t-f: Load precompiled script.\n");
+	fprintf(stderr, "\t-d: Strip debug info from precompiled script.\n");
 	exit(1);
 }
 
@@ -321,9 +322,10 @@ int main(int argc, char **argv)
 	int evalstr = 0;
 	int precompile = 0;
 	int loadprecompile = 0;
+	int striptdebug = 0;
 	int i, c;
 
-	while ((c = xgetopt(argc, argv, "isecf")) != -1) {
+	while ((c = xgetopt(argc, argv, "isecfd")) != -1) {
 		switch (c) {
 		default: usage(); break;
 		case 'i': interactive = 1; break;
@@ -331,6 +333,7 @@ int main(int argc, char **argv)
 		case 'e': evalstr = 1; break;
 		case 'c': precompile = 1; break;
 		case 'f': loadprecompile = 1; break;
+		case 'd': striptdebug = 1; break;
 		}
 	}
 
@@ -383,7 +386,7 @@ int main(int argc, char **argv)
 		} else if (precompile) {
 			if (!js_ploadfile(J, argv[c])) {
 				char *buf;
-				int size = js_dumpscript(J, -1, &buf);
+				int size = js_dumpscript(J, -1, &buf, striptdebug ? JS_BINSTRIPDEBUG : 0);
 				if (buf) {
 					char outpath[MAX_OSPATH] = {0};
 					sprintf(outpath, "./%s.out", getbasename(argv[c]));


### PR DESCRIPTION
Added `-d` flag to mujs executable to force debug info stripping.